### PR TITLE
Depth parameter

### DIFF
--- a/explode_test.go
+++ b/explode_test.go
@@ -8,7 +8,7 @@ func TestTrue(t *testing.T) {
 	input := `[true]`
 	output := `{"0":true}`
 
-	out, _ := Explodejsonstr(input, ".", 99)
+	out, _ := Explodejsonstr(input, ".", -1)
 	if out != output {
 		t.Error("got", out)
 	}
@@ -28,7 +28,7 @@ func TestNull(t *testing.T) {
 	input := `[null]`
 	output := `{"0":null}`
 
-	out, _ := Explodejsonstr(input, ".", 99)
+	out, _ := Explodejsonstr(input, ".", -1)
 	if out != output {
 		t.Error("got", out)
 	}
@@ -37,7 +37,7 @@ func TestNull(t *testing.T) {
 func TestNesting(t *testing.T) {
 	input := `{"person":{"name":"Joe", "address":{"street":"123 Main St."}}}`
 	output := `{"person.address.street":"123 Main St.","person.name":"Joe"}`
-	out, _ := Explodejsonstr(input, ".", 99)
+	out, _ := Explodejsonstr(input, ".", -1)
 	if out != output {
 		t.Error("got", out)
 	}
@@ -64,7 +64,7 @@ func TestNestedPassthrough(t *testing.T) {
 func TestNestingWithSlash(t *testing.T) {
 	input := `{"person":{"name":"Joe", "address":{"street":"123 Main St."}}}`
 	output := `{"person/address/street":"123 Main St.","person/name":"Joe"}`
-	out, _ := Explodejsonstr(input, "/", 99)
+	out, _ := Explodejsonstr(input, "/", -1)
 	if out != output {
 		t.Error("got", out)
 	}
@@ -119,7 +119,7 @@ func TestItems(t *testing.T) {
         }
     ]`
 	output := `{"0.description":"a schema given for items","0.schema.items.type":"integer","0.tests.0.data.0":1,"0.tests.0.data.1":2,"0.tests.0.data.2":3,"0.tests.0.description":"valid items","0.tests.0.valid":true,"0.tests.1.data.0":1,"0.tests.1.data.1":"x","0.tests.1.description":"wrong type of items","0.tests.1.valid":false,"0.tests.2.data.foo":"bar","0.tests.2.description":"ignores non-arrays","0.tests.2.valid":true,"1.description":"an array of schemas for items","1.schema.items.0.type":"integer","1.schema.items.1.type":"string","1.tests.0.data.0":1,"1.tests.0.data.1":"foo","1.tests.0.description":"correct types","1.tests.0.valid":true,"1.tests.1.data.0":"foo","1.tests.1.data.1":1,"1.tests.1.description":"wrong types","1.tests.1.valid":false}`
-	out, _ := Explodejsonstr(input, ".", 99)
+	out, _ := Explodejsonstr(input, ".", -1)
 	if out != output {
 		t.Error("got", out)
 	}

--- a/explode_test.go
+++ b/explode_test.go
@@ -8,7 +8,17 @@ func TestTrue(t *testing.T) {
 	input := `[true]`
 	output := `{"0":true}`
 
-	out, _ := Explodejsonstr(input, ".")
+	out, _ := Explodejsonstr(input, ".", 99)
+	if out != output {
+		t.Error("got", out)
+	}
+}
+
+func TestTruePassThrough(t *testing.T) {
+	input := `[true]`
+	output := input
+
+	out, _ := Explodejsonstr(input, ".", 0)
 	if out != output {
 		t.Error("got", out)
 	}
@@ -18,7 +28,7 @@ func TestNull(t *testing.T) {
 	input := `[null]`
 	output := `{"0":null}`
 
-	out, _ := Explodejsonstr(input, ".")
+	out, _ := Explodejsonstr(input, ".", 99)
 	if out != output {
 		t.Error("got", out)
 	}
@@ -27,7 +37,34 @@ func TestNull(t *testing.T) {
 func TestNesting(t *testing.T) {
 	input := `{"person":{"name":"Joe", "address":{"street":"123 Main St."}}}`
 	output := `{"person.address.street":"123 Main St.","person.name":"Joe"}`
-	out, _ := Explodejsonstr(input, ".")
+	out, _ := Explodejsonstr(input, ".", 99)
+	if out != output {
+		t.Error("got", out)
+	}
+}
+
+func TestNestingWithLimit(t *testing.T) {
+	input := `{"person":{"name":"Joe", "address":{"street":"123 Main St."}}}`
+	output := `{"person.address":{"street":"123 Main St."},"person.name":"Joe"}`
+	out, _ := Explodejsonstr(input, ".", 1)
+	if out != output {
+		t.Error("got", out)
+	}
+}
+
+func TestNestedPassthrough(t *testing.T) {
+	input := `{"person":{"name":"Joe", "address":{"street":"123 Main St."}}}`
+	output := input
+	out, _ := Explodejsonstr(input, ".", 0)
+	if out != output {
+		t.Error("got", out)
+	}
+}
+
+func TestNestingWithSlash(t *testing.T) {
+	input := `{"person":{"name":"Joe", "address":{"street":"123 Main St."}}}`
+	output := `{"person/address/street":"123 Main St.","person/name":"Joe"}`
+	out, _ := Explodejsonstr(input, "/", 99)
 	if out != output {
 		t.Error("got", out)
 	}
@@ -82,7 +119,62 @@ func TestItems(t *testing.T) {
         }
     ]`
 	output := `{"0.description":"a schema given for items","0.schema.items.type":"integer","0.tests.0.data.0":1,"0.tests.0.data.1":2,"0.tests.0.data.2":3,"0.tests.0.description":"valid items","0.tests.0.valid":true,"0.tests.1.data.0":1,"0.tests.1.data.1":"x","0.tests.1.description":"wrong type of items","0.tests.1.valid":false,"0.tests.2.data.foo":"bar","0.tests.2.description":"ignores non-arrays","0.tests.2.valid":true,"1.description":"an array of schemas for items","1.schema.items.0.type":"integer","1.schema.items.1.type":"string","1.tests.0.data.0":1,"1.tests.0.data.1":"foo","1.tests.0.description":"correct types","1.tests.0.valid":true,"1.tests.1.data.0":"foo","1.tests.1.data.1":1,"1.tests.1.description":"wrong types","1.tests.1.valid":false}`
-	out, _ := Explodejsonstr(input, ".")
+	out, _ := Explodejsonstr(input, ".", 99)
+	if out != output {
+		t.Error("got", out)
+	}
+}
+
+func TestItemsWithLimit(t *testing.T) {
+	input := `
+    [
+        {
+            "description": "a schema given for items",
+            "schema": {
+                "items": {"type": "integer"}
+            },
+            "tests": [
+                {
+                    "description": "valid items",
+                    "data": [ 1, 2, 3 ],
+                    "valid": true
+                },
+                {
+                    "description": "wrong type of items",
+                    "data": [1, "x"],
+                    "valid": false
+                },
+                {
+                    "description": "ignores non-arrays",
+                    "data": {"foo" : "bar"},
+                    "valid": true
+                }
+            ]
+        },
+        {
+            "description": "an array of schemas for items",
+            "schema": {
+                "items": [
+                    {"type": "integer"},
+                    {"type": "string"}
+                ]
+            },
+            "tests": [
+                {
+                    "description": "correct types",
+                    "data": [ 1, "foo" ],
+                    "valid": true
+                },
+                {
+                    "description": "wrong types",
+                    "data": [ "foo", 1 ],
+                    "valid": false
+                }
+            ]
+        }
+    ]`
+	output := `{"0.description":"a schema given for items","0.schema.items":{"type":"integer"},"0.tests.0":{"data":[1,2,3],"description":"valid items","valid":true},"0.tests.1":{"data":[1,"x"],"description":"wrong type of items","valid":false},"0.tests.2":{"data":{"foo":"bar"},"description":"ignores non-arrays","valid":true},"1.description":"an array of schemas for items","1.schema.items":[{"type":"integer"},{"type":"string"}],"1.tests.0":{"data":[1,"foo"],"description":"correct types","valid":true},"1.tests.1":{"data":["foo",1],"description":"wrong types","valid":false}}`
+	out, _ := Explodejsonstr(input, ".", 2)
 	if out != output {
 		t.Error("got", out)
 	}

--- a/gojsonexplode.go
+++ b/gojsonexplode.go
@@ -148,6 +148,14 @@ func Explodejson(b []byte, d string, depth int) ([]byte, error) {
 // parameters to pass to the function are
 // * s: the JSON string
 // * d: the delimiter to use when unnesting the JSON object.
+// * depth : the desired depth of nesting
+//   -1 = no depth limit
+//    0 = no nesting ( returns same as input )
+//    1 = only first parent will be nested, e.g. company.address
+//    2 = up until second child, e.g. company.adress.street
+//    3 = ...
+// Set to -1 if depth limit is not desired
+//
 // {"person":{"name":"Joe", "address":{"street":"123 Main St."}}}
 // explodes to:
 // {"person.name":"Joe", "person.address.street":"123 Main St."}


### PR DESCRIPTION
We needed an option to require a maximum depth of nesting. The default behaviour still works with specifying a negative value `-1`, no nesting is done with `0` and depth can be specified with any values above.

I don't know if you still maintain the project, but if this is interesting for you please feel free to merge, then I'd remove our fork. Otherwise feel free to ignore :-)

Added also some further test cases to test for the depth and a different merge character.

Note : This is a breaking change, since a parameter was added.

Cheers!
