### PR TITLE
Modified code so that if there is an empty array it will still return ...

### DIFF
--- a/gojsonexplode.go
+++ b/gojsonexplode.go
@@ -12,6 +12,10 @@ func explodeList(l []interface{}, parent string, delimiter string) (map[string]i
 	var err error
 	var key string
 	j := make(map[string]interface{})
+	if len(l) == 0 {
+		key = parent
+		j[key] = nil
+	}
 	for k, i := range l {
 		if len(parent) > 0 {
 			key = parent + delimiter + strconv.Itoa(k)


### PR DESCRIPTION
…the key with a null value, whereas before it excluded the key altogether.


eg:  input json: 

`{"a":[{"b" : []}]}`

will now return:

{"a.0.b":null}

instead of an empty result.